### PR TITLE
Remove "apt-get update" since it is not explicitly used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ python:
   - "3.6"
 
 install:
-  - sudo apt-get update
-
   # Setup using Conda (http://conda.pydata.org/docs/travis.html)
   #
   # For our case, it is a whole more interesting as:


### PR DESCRIPTION
I don't see were we use that and right now it is failing quite frequently due that.