### PR TITLE
Allow to define an env var to disable auto rerun of tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -258,6 +258,9 @@ def pytest_collection_modifyitems(items):
 
     See pytest-rerunfailures plugin for more information.
     """
+    import os
+    if os.environ.get('CI', 'false') != 'true':
+        return
     for item in items:
         if 'graph_cases' in getattr(item, 'fixturenames', []):
             item.add_marker(pytest.mark.flaky(reruns=3))


### PR DESCRIPTION
Allow to define an env var to disable auto rerun of tests using the `graph_cases` fixtures. I know this was introduced to help CI builds not to fail due flakiness but it is realy annoing when running test localy.
