### PR TITLE
Force a refresh after changing a cell's style.

### DIFF
--- a/qmxgraph/page/api.js
+++ b/qmxgraph/page/api.js
@@ -1052,6 +1052,7 @@ graphs.Api.prototype.setStyle = function setStyle(cellId, style) {
     var model = graph.getModel();
     var cell = this._findCell(model, cellId);
     model.setStyle(cell, style);  // Use the model to trigger mxStyleChange as needed.
+    graph.refresh(cell); // Force a refresh of that cell to guarantee
 };
 
 /**


### PR DESCRIPTION
I couldn't detect if it was a misuse or some bug, but this added refresh fixes it. And I couldn't find a way to programmatically test it. Basically we were doing a `set_style(cell, new_style)` and the returned value from `get_style(cell)` was the expected one (`new_style`), but visually the style didn't change.
