### PR TITLE
Restrict pytest-selenium version matcher

### DIFF
--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -25,7 +25,7 @@ dependencies:
     - pytest-mock
     - pytest-qt
     - pytest-rerunfailures
-    - pytest-selenium
+    - pytest-selenium >=1,<2
     - pytest-timeout
         {% if sys.platform != 'win32' %}
     - pytest-xvfb

--- a/esss_environment.devenv.yml
+++ b/esss_environment.devenv.yml
@@ -1,4 +1,4 @@
-{% set TEST_QMXGRAPH = os.environ.get('TEST_QMXGRAPH', '0') != '0' %}
+% set TEST_QMXGRAPH = os.environ.get('TEST_QMXGRAPH', '0') != '0' %}
 
 name: qmxgraph
 
@@ -53,7 +53,7 @@ dependencies:
     - phantomjs>=2.1
     - pytest-mock>=1.4.0
     - pytest-qt>=2.1.0
-    - pytest-selenium>=1.2.1
+    - pytest-selenium>=1.2.1,<2
     - pytest-timeout>=1.0.0
     - pytest-xdist>=1.15
         {% if sys.platform != 'win32' %}


### PR DESCRIPTION
pytest-selenium did drop support for PhantomJS in version 2.0.0.

Not the port for a newer qt, just to get build passing.