### PR TITLE
Remove dependency to fix-and-check-env

### DIFF
--- a/esss_environment.devenv.yml
+++ b/esss_environment.devenv.yml
@@ -42,7 +42,6 @@ dependencies:
 
     - attrs>=17
     - colorama
-    - fix-and-check-env>=1.0.0
     - invoke>=1.0.0
     - jinja2==2.10
     - pyqt>=5.6,<5.7


### PR DESCRIPTION
This is an internal package and shouldn't be necessary to be explicitly
included.

It also seems to be obsolete, we are in the process of removing it altogether.