### PR TITLE
Add a flag to control coordinates "screen to world" mapping in `inser…

### DIFF
--- a/src/qmxgraph/api.py
+++ b/src/qmxgraph/api.py
@@ -41,7 +41,18 @@ class QmxGraphApi(object):
         self._graph = weakref.ref(graph)
         self._call_context_manager_factory = call_context_manager_factory
 
-    def insert_vertex(self, x, y, width, height, label, style=None, tags=None, id=None):
+    def insert_vertex(
+        self,
+        x,
+        y,
+        width,
+        height,
+        label,
+        style=None,
+        tags=None,
+        id=None,
+        adjust_xy_coordinates=True,
+    ):
         """
         Inserts a new vertex in graph.
 
@@ -59,10 +70,15 @@ class QmxGraphApi(object):
             interaction with cells in a graph.
         :param Optional[str] id: The id of the edge. If omitted (or non
             unique) an id is generated.
+        :param bool adjust_xy_coordinates: A flag indicating the received X and Y
+            coordinates should be adjusted using current zoom and pan (screen to
+            world transformation).
         :rtype: str
         :return: Id of new vertex.
         """
-        return self.call_api('insertVertex', x, y, width, height, label, style, tags, id)
+        return self.call_api(
+            'insertVertex', x, y, width, height, label, style, tags, id, adjust_xy_coordinates
+        )
 
     def insert_port(
         self, vertex_id, port_name, x, y, width, height, label=None, style=None, tags=None

--- a/src/qmxgraph/page/api.js
+++ b/src/qmxgraph/page/api.js
@@ -53,6 +53,8 @@ graphs.Api.TARGET_TERMINAL_CELL = "target";
  * attributes that may be added to a cell that may be later queried (or even modified), with the
  * objective of allowing better inspection and interaction with cells in a graph.
  * @param {number} [id] The id of the vertex. If omitted (or non unique) an id is generated.
+ * @param {boolean} [adjustXYCcoordinates=true] A flag indicating the received X and Y coordinates
+ * should be adjusted using current zoom and pan (screen to world transformation).
  * @returns {number} Id of new vertex.
  */
 graphs.Api.prototype.insertVertex = function insertVertex(
@@ -63,15 +65,24 @@ graphs.Api.prototype.insertVertex = function insertVertex(
     label,
     style,
     tags,
-    id
+    id,
+    adjustXYCcoordinates
 ) {
     "use strict";
 
-    var graph = this._graphEditor.graph;
-    var coords = graphs.utils.adjustCoordinates(graph, x, y);
-
     if (id === undefined) {
         id = null;
+    }
+    if (adjustXYCcoordinates === undefined) {
+        adjustXYCcoordinates = true;
+    }
+
+    var graph = this._graphEditor.graph;
+    var coords;
+    if (adjustXYCcoordinates) {
+        coords = graphs.utils.adjustCoordinates(graph, x, y);
+    } else {
+        coords = { x: x, y: y };
     }
 
     var value = this._prepareCellValue(label, tags);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -678,7 +678,7 @@ class BaseGraphCase(object):
     def eval_js_function(self, fn, *args):
         """
         :param str fn: A function expression in JavaScript.
-        :param tuple args: Positional arguments passed to JavaScript function.
+        :param object args: Positional arguments passed to JavaScript function.
         :rtype: object
         :return: Return obtained by evaluation of given function.
         """

--- a/tests/test_js_graph.py
+++ b/tests/test_js_graph.py
@@ -41,6 +41,36 @@ def test_insert_vertex(graph_cases) -> None:
     assert graph.get_vertex() is not None
 
 
+def test_insert_vertex_with_zoom_and_scale(graph_cases) -> None:
+    """
+    :type graph_cases: qmxgraph.tests.conftest.GraphCaseFactory
+    """
+    graph = graph_cases('empty')
+    x = 10
+    y = 20
+    w = 30
+    h = 40
+    scale = 2
+    trans_x = 8
+    trans_y = 7
+    graph.eval_js_function('api.setScaleAndTranslation', scale, trans_x, trans_y)
+
+    # `adjustXYCcoordinates` value `undefined` defaults to `true`.
+    graph.eval_js_function('api.insertVertex', x, y, w, h, '', '', {}, 'adjusted-1')
+    graph.eval_js_function('api.insertVertex', x, y, w, h, '', '', {}, 'adjusted-2', True)
+    adjusted1_bounds = graph.eval_js_function('api.getCellBounds', 'adjusted-1')
+    adjusted2_bounds = graph.eval_js_function('api.getCellBounds', 'adjusted-2')
+    assert adjusted2_bounds == adjusted1_bounds
+    assert adjusted1_bounds['x'] == (x / scale) - trans_x == -3
+    assert adjusted1_bounds['y'] == (y / scale) - trans_y == 3
+
+    # When `adjustXYCcoordinates` is `false` values are taken on face value.
+    graph.eval_js_function('api.insertVertex', x, y, w, h, '', '', {}, 'absolute', False)
+    absolute_bounds = graph.eval_js_function('api.getCellBounds', 'absolute')
+    assert absolute_bounds['x'] == x
+    assert absolute_bounds['y'] == y
+
+
 @pytest.mark.parametrize('dumped,restored', [('1v', '2v'), ('2v', '1v')])
 def test_dump_restore(dumped, restored, graph_cases) -> None:
     """


### PR DESCRIPTION
…t_vertex`

Disabling screen to world mapping will make it easier to programmatic
create vertexes when zoom and pan are present.