### PR TITLE
Handle child cells in registerCellsAddedHandler

### DIFF
--- a/src/qmxgraph/api.py
+++ b/src/qmxgraph/api.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from typing import Any
 from typing import Generator
 from typing import List
+from typing import Sequence
 
 import qmxgraph.debug
 import qmxgraph.js
@@ -570,6 +571,28 @@ class QmxGraphApi(object):
         """
         return self.call_api('removeCells', cell_ids, ignore_missing_cells)
 
+    def clone_cells(
+        self,
+        cell_ids: Sequence[str],
+        ignore_missing_cells: bool = False,
+        offset_x: int = 10,
+        offset_y: int = 10,
+    ) -> List[str]:
+        """
+        Clone cells and add them to the graph.
+
+        :param cell_ids: Ids of cells to be cloned.
+        :param ignore_missing_cells: Ids of non existent cells are ignored instead of
+            raising an error.
+        :param offset_x: Offset to be applied to the new cells in pixels
+        :param offset_y: Offset to be applied to the new cells in pixels
+        """
+        new_cell_ids = self.call_api(
+            'cloneCells', cell_ids, ignore_missing_cells, offset_x, offset_y
+        )
+        self.set_selected_cells(new_cell_ids)
+        return new_cell_ids
+
     def remove_port(self, vertex_id, port_name):
         """
         Remove an existing port from a vertex. Any edge connected to the
@@ -1006,8 +1029,7 @@ def _capture_critical_log_messages() -> Generator[List[str], None, None]:
     of type QtCriticalMsg. The context manager returns a list of captured messages,
     which can be inspected after the context manager ends.
     """
-    from PyQt5.QtCore import QtCriticalMsg
-    from PyQt5.QtCore import qInstallMessageHandler
+    from PyQt5.QtCore import QtCriticalMsg, qInstallMessageHandler
 
     messages = []
 

--- a/src/qmxgraph/page/api.js
+++ b/src/qmxgraph/page/api.js
@@ -1192,121 +1192,117 @@ graphs.Api.prototype.cloneCells = function cloneCells(
  * keepPosition - Optional boolean indicating if the position of the cells should
  * be updated to reflect the lost parent cell. Default is false.
  */
-graphs.Api.prototype._cloneCells = function _cloneCells(cells, allowInvalidEdges, mapping, keepPosition)
-{
-	allowInvalidEdges = (allowInvalidEdges != null) ? allowInvalidEdges : true;
-	var clones = null;
+graphs.Api.prototype._cloneCells = function _cloneCells(
+    cells,
+    allowInvalidEdges,
+    mapping,
+    keepPosition
+) {
+    allowInvalidEdges = allowInvalidEdges != null ? allowInvalidEdges : true;
+    var clones = null;
 
-	if (cells != null)
-	{
+    if (cells != null) {
         var graph = this._graphEditor.graph;
 
-		// Creates a dictionary for fast lookups
-		var dict = new mxDictionary();
-		var tmp = [];
+        // Creates a dictionary for fast lookups
+        var dict = new mxDictionary();
+        var tmp = [];
 
-		for (var i = 0; i < cells.length; i++)
-		{
-			dict.put(cells[i], true);
-			tmp.push(cells[i]);
-		}
+        for (var i = 0; i < cells.length; i++) {
+            dict.put(cells[i], true);
+            tmp.push(cells[i]);
+        }
 
-		if (tmp.length > 0)
-		{
-			var scale = graph.view.scale;
-			var trans = graph.view.translate;
-			clones = this._modelCloneCells(cells, true, mapping);
+        if (tmp.length > 0) {
+            var scale = graph.view.scale;
+            var trans = graph.view.translate;
+            clones = this._modelCloneCells(cells, true, mapping);
 
-			for (var i = 0; i < cells.length; i++)
-			{
-				if (!allowInvalidEdges && graph.model.isEdge(clones[i]) &&
-					graph.getEdgeValidationError(clones[i],
-						graph.model.getTerminal(clones[i], true),
-						graph.model.getTerminal(clones[i], false)) != null)
-				{
-					clones[i] = null;
-				}
-				else
-				{
-					var g = graph.model.getGeometry(clones[i]);
+            for (var i = 0; i < cells.length; i++) {
+                if (
+                    !allowInvalidEdges &&
+                    graph.model.isEdge(clones[i]) &&
+                    graph.getEdgeValidationError(
+                        clones[i],
+                        graph.model.getTerminal(clones[i], true),
+                        graph.model.getTerminal(clones[i], false)
+                    ) != null
+                ) {
+                    clones[i] = null;
+                } else {
+                    var g = graph.model.getGeometry(clones[i]);
 
-					if (g != null)
-					{
-						var state = graph.view.getState(cells[i]);
-						var pstate = graph.view.getState(graph.model.getParent(cells[i]));
+                    if (g != null) {
+                        var state = graph.view.getState(cells[i]);
+                        var pstate = graph.view.getState(graph.model.getParent(cells[i]));
 
-						if (state != null && pstate != null)
-						{
-							var dx = (keepPosition) ? 0 : pstate.origin.x;
-							var dy = (keepPosition) ? 0 : pstate.origin.y;
+                        if (state != null && pstate != null) {
+                            var dx = keepPosition ? 0 : pstate.origin.x;
+                            var dy = keepPosition ? 0 : pstate.origin.y;
 
-							if (graph.model.isEdge(clones[i]))
-							{
-								var pts = state.absolutePoints;
+                            if (graph.model.isEdge(clones[i])) {
+                                var pts = state.absolutePoints;
 
-								if (pts != null)
-								{
-									// Checks if the source is cloned or sets the terminal point
-									var src = graph.model.getTerminal(cells[i], true);
+                                if (pts != null) {
+                                    // Checks if the source is cloned or sets the terminal point
+                                    var src = graph.model.getTerminal(cells[i], true);
 
-									while (src != null && !dict.get(src))
-									{
-										src = graph.model.getParent(src);
-									}
+                                    while (src != null && !dict.get(src)) {
+                                        src = graph.model.getParent(src);
+                                    }
 
-									if (src == null && pts[0] != null)
-									{
-										g.setTerminalPoint(
-											new mxPoint(pts[0].x / scale - trans.x,
-												pts[0].y / scale - trans.y), true);
-									}
+                                    if (src == null && pts[0] != null) {
+                                        g.setTerminalPoint(
+                                            new mxPoint(
+                                                pts[0].x / scale - trans.x,
+                                                pts[0].y / scale - trans.y
+                                            ),
+                                            true
+                                        );
+                                    }
 
-									// Checks if the target is cloned or sets the terminal point
-									var trg = graph.model.getTerminal(cells[i], false);
+                                    // Checks if the target is cloned or sets the terminal point
+                                    var trg = graph.model.getTerminal(cells[i], false);
 
-									while (trg != null && !dict.get(trg))
-									{
-										trg = graph.model.getParent(trg);
-									}
+                                    while (trg != null && !dict.get(trg)) {
+                                        trg = graph.model.getParent(trg);
+                                    }
 
-									var n = pts.length - 1;
+                                    var n = pts.length - 1;
 
-									if (trg == null && pts[n] != null)
-									{
-										g.setTerminalPoint(
-											new mxPoint(pts[n].x / scale - trans.x,
-												pts[n].y / scale - trans.y), false);
-									}
+                                    if (trg == null && pts[n] != null) {
+                                        g.setTerminalPoint(
+                                            new mxPoint(
+                                                pts[n].x / scale - trans.x,
+                                                pts[n].y / scale - trans.y
+                                            ),
+                                            false
+                                        );
+                                    }
 
-									// Translates the control points
-									var points = g.points;
+                                    // Translates the control points
+                                    var points = g.points;
 
-									if (points != null)
-									{
-										for (var j = 0; j < points.length; j++)
-										{
-											points[j].x += dx;
-											points[j].y += dy;
-										}
-									}
-								}
-							}
-							else
-							{
-								g.translate(dx, dy);
-							}
-						}
-					}
-				}
-			}
-		}
-		else
-		{
-			clones = [];
-		}
-	}
+                                    if (points != null) {
+                                        for (var j = 0; j < points.length; j++) {
+                                            points[j].x += dx;
+                                            points[j].y += dy;
+                                        }
+                                    }
+                                }
+                            } else {
+                                g.translate(dx, dy);
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            clones = [];
+        }
+    }
 
-	return clones;
+    return clones;
 };
 
 /**
@@ -1324,35 +1320,28 @@ graphs.Api.prototype._cloneCells = function _cloneCells(cells, allowInvalidEdges
  * with all descendants. Default is true.
  * mapping - Optional mapping for existing clones.
  */
-graphs.Api.prototype._modelCloneCells = function _modelCloneCells(cells, includeChildren, mapping)
-{
-	includeChildren = (includeChildren != null) ? includeChildren : true;
-	mapping = (mapping != null) ? mapping : new Object();
-	var clones = [];
+graphs.Api.prototype._modelCloneCells = function _modelCloneCells(cells, includeChildren, mapping) {
+    includeChildren = includeChildren != null ? includeChildren : true;
+    mapping = mapping != null ? mapping : new Object();
+    var clones = [];
 
     var model = this._graphEditor.graph.getModel();
 
-	for (var i = 0; i < cells.length; i++)
-	{
-		if (cells[i] != null)
-		{
-			clones.push(this._modelCloneCellImpl(cells[i], mapping, includeChildren));
-		}
-		else
-		{
-			clones.push(null);
-		}
-	}
+    for (var i = 0; i < cells.length; i++) {
+        if (cells[i] != null) {
+            clones.push(this._modelCloneCellImpl(cells[i], mapping, includeChildren));
+        } else {
+            clones.push(null);
+        }
+    }
 
-	for (var i = 0; i < clones.length; i++)
-	{
-		if (clones[i] != null)
-		{
-			model.restoreClone(clones[i], cells[i], mapping); // TODO: keep an eye on this
-		}
-	}
+    for (var i = 0; i < clones.length; i++) {
+        if (clones[i] != null) {
+            model.restoreClone(clones[i], cells[i], mapping); // TODO: keep an eye on this
+        }
+    }
 
-	return clones;
+    return clones;
 };
 
 /**
@@ -1360,35 +1349,35 @@ graphs.Api.prototype._modelCloneCells = function _modelCloneCells(cells, include
  *
  * Inner helper method for cloning cells recursively.
  */
-graphs.Api.prototype._modelCloneCellImpl = function _modelCloneCellImpl(cell, mapping, includeChildren)
-{
-	var ident = mxObjectIdentity.get(cell);
-	var clone = mapping[ident];
+graphs.Api.prototype._modelCloneCellImpl = function _modelCloneCellImpl(
+    cell,
+    mapping,
+    includeChildren
+) {
+    var ident = mxObjectIdentity.get(cell);
+    var clone = mapping[ident];
 
-	if (clone == null)
-	{
+    if (clone == null) {
         var model = this._graphEditor.graph.getModel();
 
-		clone = model.cellCloned(cell);
-		mapping[ident] = clone;
+        clone = model.cellCloned(cell);
+        mapping[ident] = clone;
 
-		if (includeChildren)
-		{
-			var childCount = model.getChildCount(cell);
+        if (includeChildren) {
+            var childCount = model.getChildCount(cell);
 
-			for (var i = 0; i < childCount; i++)
-			{
+            for (var i = 0; i < childCount; i++) {
                 var child = model.getChildAt(cell, i);
                 if (child.isPort()) {
                     continue;
                 }
-				var cloneChild = this._modelCloneCellImpl(child, mapping, true);
+                var cloneChild = this._modelCloneCellImpl(child, mapping, true);
                 clone.insert(cloneChild);
-			}
-		}
-	}
+            }
+        }
+    }
 
-	return clone;
+    return clone;
 };
 
 /**

--- a/src/qmxgraph/widget.py
+++ b/src/qmxgraph/widget.py
@@ -8,6 +8,7 @@ from typing import Any
 from typing import Callable
 from typing import DefaultDict
 from typing import List
+from typing import Sequence
 
 from oop_ext.foundation.callback import Callback
 from PyQt5.QtCore import pyqtSignal
@@ -41,7 +42,10 @@ from qmxgraph.waiting import wait_until
 # Some ugliness to successfully build the doc on ReadTheDocs...
 on_rtd = os.environ.get('READTHEDOCS') == 'True'
 if not on_rtd:
-    from qmxgraph import resource_mxgraph, resource_qmxgraph  # type:ignore[attr-defined]
+    from qmxgraph import (
+        resource_mxgraph,  # type:ignore[attr-defined]
+        resource_qmxgraph,
+    )
 
 
 class QmxGraph(QWidget):
@@ -389,6 +393,32 @@ class QmxGraph(QWidget):
         """
         with wait_signals_called(self._events_bridge.on_cells_removed):
             self.api.remove_cells(cell_ids, ignore_missing_cells=ignore_missing_cells)
+
+    def clone_cells(
+        self,
+        cell_ids: Sequence[str],
+        *,
+        ignore_missing_cells: bool = False,
+        offset_x: int = 10,
+        offset_y: int = 10,
+    ) -> List[str]:
+        """
+        Clone cells and add them to the graph.
+
+        :param cell_ids: Ids of cells to be cloned.
+        :param ignore_missing_cells: Ids of non existent cells are ignored instead of
+            raising an error.
+        :param offset_x: Offset to be applied to the new cells in pixels
+        :param offset_y: Offset to be applied to the new cells in pixels
+
+        """
+        with wait_signals_called(self._events_bridge.on_cells_added):
+            return self.api.clone_cells(
+                cell_ids,
+                ignore_missing_cells=ignore_missing_cells,
+                offset_x=offset_x,
+                offset_y=offset_y,
+            )
 
     # Accessors recommended for debugging/testing only ------------------------
 

--- a/tests/test_js_graph.py
+++ b/tests/test_js_graph.py
@@ -660,6 +660,26 @@ def test_remove_cells(graph_cases) -> None:
     assert graph.get_edge(*vertices) is None
 
 
+def test_clone_cells(graph_cases) -> None:
+    """
+    :type graph_cases: qmxgraph.tests.conftest.GraphCaseFactory
+    """
+    graph = graph_cases('2v_1e')
+
+    vertices = graph.get_vertices()
+    cell_ids = [
+        graph.get_id(vertices[0]),
+        graph.get_id(vertices[1]),
+        graph.get_id(graph.get_edge(*vertices)),
+    ]
+    graph.eval_js_function('api.cloneCells', [cell_ids])
+
+    vertices = graph.get_vertices()
+    assert len(vertices) == 4
+    assert graph.get_edge(*vertices[:2]) is not None
+    assert graph.get_edge(*vertices[2:]) is not None
+
+
 def test_remove_cells_error_not_found(graph_cases, selenium_extras) -> None:
     """
     :type graph_cases: qmxgraph.tests.conftest.GraphCaseFactory

--- a/tests/test_qt_js_integration.py
+++ b/tests/test_qt_js_integration.py
@@ -687,6 +687,26 @@ def loaded_graph_(graph):
     return graph
 
 
+def test_clone_cells(graph: QmxGraph, mocker: MockFixture) -> None:
+    events = graph.events_bridge
+    added_handler = mocker.Mock()
+    events.on_cells_added.connect(added_handler)
+
+    graph.load_and_wait()
+
+    foo_id = graph.api.insert_vertex(440, 40, 20, 20, 'foo')
+    bar_id = graph.api.insert_vertex(40, 140, 20, 20, 'bar')
+    edge_id = graph.api.insert_edge(foo_id, bar_id, 'edge')
+
+    cell_ids = [foo_id, bar_id, edge_id]
+    new_cell_ids = graph.clone_cells(cell_ids)
+
+    assert len(new_cell_ids) == 3
+    assert added_handler.call_args_list == [
+        mocker.call(cell_id) for cell_id in (cell_ids + new_cell_ids)
+    ]
+
+
 @pytest.fixture(name='drag_drop_events')
 def drag_drop_events_(mocker):
     """


### PR DESCRIPTION
Needed for [ASIM-4848](https://eden.esss.co/jira/browse/ASIM-4848). Main PR in https://github.com/ESSS/alfasim/pull/38/.

When cells are copied by ctrl+dragging, a callback is executed as the new cells are added, but decorations weren't passed along with nodes and edges (and perhaps tables).

The callback implementation for when cells are removed included some logic for recursing down into child cells, and it seems that was also required for when they're added. This PR factors that logic out from `registerCellsRemovedHandler` so it can be reused in `registerCellsAddedHandler`.

Props to @prusse-martin for basically co-authoring this.