### PR TITLE
Fix ci build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ on:
       - master
 
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
selenium package 4.27.0 was broken (missing files):
https://github.com/conda-forge/selenium-feedstock/issues/98

The 4.27.1 version have been released and it appears to be fixed.