### PR TITLE
Replace obsolete ENABLE_LLVMPIPE_GL

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -4,7 +4,7 @@ export MXGRAPHPATH=mxgraph
 
 export LIBGL_ALWAYS_SOFTWARE=1
 export GALLIUM_DRIVER=llvmpipe
-export ENABLE_LLVMPIPE_GL=1
+export ESSS_SOFTWARE_RENDERING=1
 export QT_QUICK_BACKEND=software
 export QTWEBENGINE_CHROMIUM_FLAGS="--disable-gpu --no-sandbox"
 


### PR DESCRIPTION
This environment variable has been replaced by `ESSS_SOFTWARE_RENDERING`:

https://github.com/ESSS/frozen-support/blob/54a4315006ea2080e6a9dc7b2a6efc2a8a6593fb/source/python/frozen_support/opengl.py#L43C33-L43C56

[no ci]